### PR TITLE
fix: restore CUDA graph compatibility with chunked prefill

### DIFF
--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -40,6 +40,17 @@ class ModelRunner:
 
         if self.world_size > 1:
             if rank == 0:
+                # 尝试清理已存在的共享内存
+                try:
+                    existing_shm = SharedMemory(name="nanovllm", create=False)
+                    existing_shm.close()
+                    existing_shm.unlink()  # 标记删除
+                    print(f"Cleaned up existing shared memory: nanovllm")
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    print(f"Error cleaning up shared memory: {e}")
+
                 self.shm = SharedMemory(name="nanovllm", create=True, size=2**20)
                 dist.barrier()
             else:
@@ -92,9 +103,11 @@ class ModelRunner:
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats()
         max_num_batched_tokens, max_model_len = self.config.max_num_batched_tokens, self.config.max_model_len
-        num_seqs = min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs)
+        num_seqs = max(min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs), 1)
         seqs = [Sequence([0] * max_model_len) for _ in range(num_seqs)]
-        self.run(seqs, True)
+        for seq in seqs:
+            seq.num_new_tokens = max_model_len
+        self.run(seqs)
         torch.cuda.empty_cache()
 
     def allocate_kv_cache(self):
@@ -106,41 +119,16 @@ class ModelRunner:
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
         num_kv_heads = hf_config.num_key_value_heads // self.world_size
         head_dim = getattr(hf_config, "head_dim", hf_config.hidden_size // hf_config.num_attention_heads)
-
-        if config.kv_quant:
-            # INT8 cache (1 byte/elem) + FP32 scale per (token, head) (4 bytes)
-            block_bytes = (2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * 1
-                           + 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * 4)
-        else:
-            block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.torch_dtype.itemsize
-
+        block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.torch_dtype.itemsize
         config.num_kvcache_blocks = int(total * config.gpu_memory_utilization - used - peak + current) // block_bytes
         assert config.num_kvcache_blocks > 0
-
-        if config.kv_quant:
-            self.kv_cache = torch.empty(
-                2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads * head_dim,
-                dtype=torch.int8)
-            self.kv_scale = torch.empty(
-                2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads,
-                dtype=torch.float32)
-            layer_id = 0
-            for module in self.model.modules():
-                if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
-                    module.k_cache  = self.kv_cache[0, layer_id]
-                    module.v_cache  = self.kv_cache[1, layer_id]
-                    module.k_scale  = self.kv_scale[0, layer_id]
-                    module.v_scale  = self.kv_scale[1, layer_id]
-                    module.kv_quant = True
-                    layer_id += 1
-        else:
-            self.kv_cache = torch.empty(2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads, head_dim)
-            layer_id = 0
-            for module in self.model.modules():
-                if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
-                    module.k_cache = self.kv_cache[0, layer_id]
-                    module.v_cache = self.kv_cache[1, layer_id]
-                    layer_id += 1
+        self.kv_cache = torch.empty(2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads, head_dim)
+        layer_id = 0
+        for module in self.model.modules():
+            if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
+                module.k_cache = self.kv_cache[0, layer_id]
+                module.v_cache = self.kv_cache[1, layer_id]
+                layer_id += 1
 
     def prepare_block_tables(self, seqs: list[Sequence]):
         max_len = max(len(seq.block_table) for seq in seqs)
@@ -148,7 +136,8 @@ class ModelRunner:
         block_tables = torch.tensor(block_tables, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         return block_tables
 
-    def prepare_prefill(self, seqs: list[Sequence]):
+
+    def prepare_model_input(self, seqs: list[Sequence]):
         input_ids = []
         positions = []
         cu_seqlens_q = [0]
@@ -157,89 +146,123 @@ class ModelRunner:
         max_seqlen_k = 0
         slot_mapping = []
         block_tables = None
-        for seq in seqs:
-            seqlen = len(seq)
-            input_ids.extend(seq[seq.num_cached_tokens:])
-            positions.extend(list(range(seq.num_cached_tokens, seqlen)))
-            seqlen_q = seqlen - seq.num_cached_tokens
-            seqlen_k = seqlen
+        context_lens = []
+        seq_need_compute_logits = []
+        for seq_index, seq in enumerate(seqs):
+            if len(seq) == seq.num_cached_tokens + seq.num_new_tokens and seq.block_table:
+                seq_need_compute_logits.append(seq_index)
+            context_lens.append(seq.num_context_tokens)
+            input_ids.extend(seq[seq.num_cached_tokens: seq.num_context_tokens])
+            positions.extend(list(range(seq.num_cached_tokens, seq.num_context_tokens)))
+            seqlen_q = seq.num_new_tokens
+            seqlen_k = seq.num_context_tokens
             cu_seqlens_q.append(cu_seqlens_q[-1] + seqlen_q)
             cu_seqlens_k.append(cu_seqlens_k[-1] + seqlen_k)
             max_seqlen_q = max(seqlen_q, max_seqlen_q)
             max_seqlen_k = max(seqlen_k, max_seqlen_k)
             if not seq.block_table:    # warmup
                 continue
-            for i in range(seq.num_cached_blocks, seq.num_blocks):
-                start = seq.block_table[i] * self.block_size
-                if i != seq.num_blocks - 1:
-                    end = start + self.block_size
+            for i in range(seq.num_cached_blocks, len(seq.block_table)):
+                if i == seq.num_cached_blocks:
+                    start = seq.block_table[i] * self.block_size + seq.num_cached_tokens % seq.block_size
                 else:
-                    end = start + seq.last_block_num_tokens 
+                    start = seq.block_table[i] * self.block_size
+                if i == len(seq.block_table) - 1:
+                    end = seq.block_table[i] * self.block_size + seq.num_context_tokens % self.block_size \
+                        if seq.num_context_tokens % self.block_size != 0 \
+                            else (seq.block_table[i] + 1) * self.block_size
+                else:
+                    end = (seq.block_table[i] + 1) * self.block_size
                 slot_mapping.extend(list(range(start, end)))
-        if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
+        if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache or decoding
             block_tables = self.prepare_block_tables(seqs)
         input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
         positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
         cu_seqlens_q = torch.tensor(cu_seqlens_q, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         cu_seqlens_k = torch.tensor(cu_seqlens_k, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        set_context(True, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, None, block_tables)
-        return input_ids, positions
-
-    def prepare_decode(self, seqs: list[Sequence]):
-        input_ids = []
-        positions = []
-        slot_mapping = []
-        context_lens = []
-        for seq in seqs:
-            input_ids.append(seq.last_token)
-            positions.append(len(seq) - 1)
-            context_lens.append(len(seq))
-            slot_mapping.append(seq.block_table[-1] * self.block_size + seq.last_block_num_tokens  - 1)
-        input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         context_lens = torch.tensor(context_lens, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        block_tables = self.prepare_block_tables(seqs)
-        set_context(False, slot_mapping=slot_mapping, context_lens=context_lens, block_tables=block_tables)
+        seq_need_compute_logits = torch.tensor(seq_need_compute_logits, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+        set_context(cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, context_lens, block_tables, seq_need_compute_logits)
         return input_ids, positions
 
     def prepare_sample(self, seqs: list[Sequence]):
+        context = get_context()
         temperatures = []
         for seq in seqs:
             temperatures.append(seq.temperature)
         temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
+        if context.seq_need_compute_logits.numel():
+            temperatures = temperatures[context.seq_need_compute_logits]
         return temperatures
 
-    @torch.inference_mode()
-    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill: bool):
-        if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
-            return self.model.compute_logits(self.model(input_ids, positions))
-        else:
-            bs = input_ids.size(0)
-            context = get_context()
-            graph = self.graphs[next(x for x in self.graph_bs if x >= bs)]
-            graph_vars = self.graph_vars
-            graph_vars["input_ids"][:bs] = input_ids
-            graph_vars["positions"][:bs] = positions
-            graph_vars["slot_mapping"].fill_(-1)
-            graph_vars["slot_mapping"][:bs] = context.slot_mapping
-            graph_vars["context_lens"].zero_()
-            graph_vars["context_lens"][:bs] = context.context_lens
-            graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
-            graph.replay()
-            return self.model.compute_logits(graph_vars["outputs"][:bs])
+    def _is_decode_only(self, seqs: list) -> bool:
+        """Return True only when every sequence in the batch is in pure decode
+        mode (num_new_tokens == 1, i.e. no chunked-prefill tokens in flight).
 
-    def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
-        input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
+        CUDA graphs require static tensor shapes, so we can only replay a
+        captured graph when the batch is homogeneously decode-step sequences.
+        Any prefill token – whether it is a first-prefill, a chunked-prefill
+        continuation, or a mixed prefill+decode batch – must fall back to
+        eager execution.
+        """
+        return all(seq.num_new_tokens == 1 for seq in seqs)
+
+    @torch.inference_mode()
+    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, seqs: list = None):
+        context = get_context()
+
+        # Use CUDA graph only for pure decode-only batches with static shapes.
+        # Chunked-prefill batches have variable seqlen_q > 1 and mixed
+        # prefill/decode sequences, which break the static-shape requirement
+        # of CUDA graph replay.
+        use_graph = (
+            not self.enforce_eager
+            and input_ids.size(0) <= 512
+            and seqs is not None
+            and self._is_decode_only(seqs)
+        )
+
+        if not use_graph:
+            return self.model.compute_logits(self.model(input_ids, positions))
+
+        # --- CUDA graph replay path (decode-only) ---
+        bs = input_ids.size(0)
+        graph = self.graphs[next(x for x in self.graph_bs if x >= bs)]
+        graph_vars = self.graph_vars
+        graph_vars["input_ids"][:bs] = input_ids
+        graph_vars["positions"][:bs] = positions
+        graph_vars["slot_mapping"].fill_(-1)
+        graph_vars["slot_mapping"][:bs] = context.slot_mapping
+        graph_vars["context_lens"].zero_()
+        graph_vars["context_lens"][:bs] = context.context_lens
+        graph_vars["block_tables"].zero_()
+        graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
+        graph.replay()
+        return self.model.compute_logits(graph_vars["outputs"][:bs])
+
+    def run(self, seqs: list[Sequence]) -> list[int]:
+        input_ids, positions = self.prepare_model_input(seqs)
         temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
-        logits = self.run_model(input_ids, positions, is_prefill)
+        logits = self.run_model(input_ids, positions, seqs)
         token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+        seq_need_compute_logits = get_context().seq_need_compute_logits
         reset_context()
-        return token_ids
+        return token_ids, seq_need_compute_logits
 
     @torch.inference_mode()
     def capture_cudagraph(self):
+        """Capture CUDA graphs for the decode-only case.
+
+        Graphs are only replayed when every sequence in the batch has
+        ``num_new_tokens == 1`` (pure decode step, no chunked prefill).
+        During prefill – including chunked-prefill iterations – the engine
+        falls back to eager execution, so the captured graphs never receive
+        variable-length prefill inputs.
+
+        Capture is performed for a set of bucket batch-sizes so that we can
+        always find the smallest bucket >= the live batch size at replay time.
+        """
         config = self.config
         hf_config = config.hf_config
         max_bs = min(self.config.max_num_seqs, 512)
@@ -256,7 +279,7 @@ class ModelRunner:
 
         for bs in reversed(self.graph_bs):
             graph = torch.cuda.CUDAGraph()
-            set_context(False, slot_mapping=slot_mapping[:bs], context_lens=context_lens[:bs], block_tables=block_tables[:bs])
+            set_context(slot_mapping=slot_mapping[:bs], context_lens=context_lens[:bs], block_tables=block_tables[:bs])
             outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # warmup
             with torch.cuda.graph(graph, self.graph_pool):
                 outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # capture

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -40,17 +40,6 @@ class ModelRunner:
 
         if self.world_size > 1:
             if rank == 0:
-                # 尝试清理已存在的共享内存
-                try:
-                    existing_shm = SharedMemory(name="nanovllm", create=False)
-                    existing_shm.close()
-                    existing_shm.unlink()  # 标记删除
-                    print(f"Cleaned up existing shared memory: nanovllm")
-                except FileNotFoundError:
-                    pass
-                except Exception as e:
-                    print(f"Error cleaning up shared memory: {e}")
-
                 self.shm = SharedMemory(name="nanovllm", create=True, size=2**20)
                 dist.barrier()
             else:
@@ -103,11 +92,9 @@ class ModelRunner:
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats()
         max_num_batched_tokens, max_model_len = self.config.max_num_batched_tokens, self.config.max_model_len
-        num_seqs = max(min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs), 1)
+        num_seqs = min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs)
         seqs = [Sequence([0] * max_model_len) for _ in range(num_seqs)]
-        for seq in seqs:
-            seq.num_new_tokens = max_model_len
-        self.run(seqs)
+        self.run(seqs, True)
         torch.cuda.empty_cache()
 
     def allocate_kv_cache(self):
@@ -119,16 +106,41 @@ class ModelRunner:
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
         num_kv_heads = hf_config.num_key_value_heads // self.world_size
         head_dim = getattr(hf_config, "head_dim", hf_config.hidden_size // hf_config.num_attention_heads)
-        block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.torch_dtype.itemsize
+
+        if config.kv_quant:
+            # INT8 cache (1 byte/elem) + FP32 scale per (token, head) (4 bytes)
+            block_bytes = (2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * 1
+                           + 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * 4)
+        else:
+            block_bytes = 2 * hf_config.num_hidden_layers * self.block_size * num_kv_heads * head_dim * hf_config.torch_dtype.itemsize
+
         config.num_kvcache_blocks = int(total * config.gpu_memory_utilization - used - peak + current) // block_bytes
         assert config.num_kvcache_blocks > 0
-        self.kv_cache = torch.empty(2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads, head_dim)
-        layer_id = 0
-        for module in self.model.modules():
-            if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
-                module.k_cache = self.kv_cache[0, layer_id]
-                module.v_cache = self.kv_cache[1, layer_id]
-                layer_id += 1
+
+        if config.kv_quant:
+            self.kv_cache = torch.empty(
+                2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads * head_dim,
+                dtype=torch.int8)
+            self.kv_scale = torch.empty(
+                2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads,
+                dtype=torch.float32)
+            layer_id = 0
+            for module in self.model.modules():
+                if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
+                    module.k_cache  = self.kv_cache[0, layer_id]
+                    module.v_cache  = self.kv_cache[1, layer_id]
+                    module.k_scale  = self.kv_scale[0, layer_id]
+                    module.v_scale  = self.kv_scale[1, layer_id]
+                    module.kv_quant = True
+                    layer_id += 1
+        else:
+            self.kv_cache = torch.empty(2, hf_config.num_hidden_layers, config.num_kvcache_blocks, self.block_size, num_kv_heads, head_dim)
+            layer_id = 0
+            for module in self.model.modules():
+                if hasattr(module, "k_cache") and hasattr(module, "v_cache"):
+                    module.k_cache = self.kv_cache[0, layer_id]
+                    module.v_cache = self.kv_cache[1, layer_id]
+                    layer_id += 1
 
     def prepare_block_tables(self, seqs: list[Sequence]):
         max_len = max(len(seq.block_table) for seq in seqs)
@@ -136,8 +148,7 @@ class ModelRunner:
         block_tables = torch.tensor(block_tables, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         return block_tables
 
-
-    def prepare_model_input(self, seqs: list[Sequence]):
+    def prepare_prefill(self, seqs: list[Sequence]):
         input_ids = []
         positions = []
         cu_seqlens_q = [0]
@@ -146,59 +157,63 @@ class ModelRunner:
         max_seqlen_k = 0
         slot_mapping = []
         block_tables = None
-        context_lens = []
-        seq_need_compute_logits = []
-        for seq_index, seq in enumerate(seqs):
-            if len(seq) == seq.num_cached_tokens + seq.num_new_tokens and seq.block_table:
-                seq_need_compute_logits.append(seq_index)
-            context_lens.append(seq.num_context_tokens)
-            input_ids.extend(seq[seq.num_cached_tokens: seq.num_context_tokens])
-            positions.extend(list(range(seq.num_cached_tokens, seq.num_context_tokens)))
-            seqlen_q = seq.num_new_tokens
-            seqlen_k = seq.num_context_tokens
+        for seq in seqs:
+            seqlen = len(seq)
+            input_ids.extend(seq[seq.num_cached_tokens:])
+            positions.extend(list(range(seq.num_cached_tokens, seqlen)))
+            seqlen_q = seqlen - seq.num_cached_tokens
+            seqlen_k = seqlen
             cu_seqlens_q.append(cu_seqlens_q[-1] + seqlen_q)
             cu_seqlens_k.append(cu_seqlens_k[-1] + seqlen_k)
             max_seqlen_q = max(seqlen_q, max_seqlen_q)
             max_seqlen_k = max(seqlen_k, max_seqlen_k)
             if not seq.block_table:    # warmup
                 continue
-            for i in range(seq.num_cached_blocks, len(seq.block_table)):
-                if i == seq.num_cached_blocks:
-                    start = seq.block_table[i] * self.block_size + seq.num_cached_tokens % seq.block_size
+            for i in range(seq.num_cached_blocks, seq.num_blocks):
+                start = seq.block_table[i] * self.block_size
+                if i != seq.num_blocks - 1:
+                    end = start + self.block_size
                 else:
-                    start = seq.block_table[i] * self.block_size
-                if i == len(seq.block_table) - 1:
-                    end = seq.block_table[i] * self.block_size + seq.num_context_tokens % self.block_size \
-                        if seq.num_context_tokens % self.block_size != 0 \
-                            else (seq.block_table[i] + 1) * self.block_size
-                else:
-                    end = (seq.block_table[i] + 1) * self.block_size
+                    end = start + seq.last_block_num_tokens 
                 slot_mapping.extend(list(range(start, end)))
-        if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache or decoding
+        if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
             block_tables = self.prepare_block_tables(seqs)
         input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
         positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
         cu_seqlens_q = torch.tensor(cu_seqlens_q, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         cu_seqlens_k = torch.tensor(cu_seqlens_k, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+        set_context(True, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, None, block_tables)
+        return input_ids, positions
+
+    def prepare_decode(self, seqs: list[Sequence]):
+        input_ids = []
+        positions = []
+        slot_mapping = []
+        context_lens = []
+        for seq in seqs:
+            input_ids.append(seq.last_token)
+            positions.append(len(seq) - 1)
+            context_lens.append(len(seq))
+            slot_mapping.append(seq.block_table[-1] * self.block_size + seq.last_block_num_tokens  - 1)
+        input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
+        positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
+        slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         context_lens = torch.tensor(context_lens, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        seq_need_compute_logits = torch.tensor(seq_need_compute_logits, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
-        set_context(cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, context_lens, block_tables, seq_need_compute_logits)
+        block_tables = self.prepare_block_tables(seqs)
+        set_context(False, slot_mapping=slot_mapping, context_lens=context_lens, block_tables=block_tables)
         return input_ids, positions
 
     def prepare_sample(self, seqs: list[Sequence]):
-        context = get_context()
         temperatures = []
         for seq in seqs:
             temperatures.append(seq.temperature)
         temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
-        if context.seq_need_compute_logits.numel():
-            temperatures = temperatures[context.seq_need_compute_logits]
         return temperatures
 
     @torch.inference_mode()
-    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor):
-        if self.enforce_eager or input_ids.size(0) > 512:
+    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill: bool):
+        if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
             return self.model.compute_logits(self.model(input_ids, positions))
         else:
             bs = input_ids.size(0)
@@ -215,14 +230,13 @@ class ModelRunner:
             graph.replay()
             return self.model.compute_logits(graph_vars["outputs"][:bs])
 
-    def run(self, seqs: list[Sequence]) -> list[int]:
-        input_ids, positions = self.prepare_model_input(seqs)
+    def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
+        input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
         temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
-        logits = self.run_model(input_ids, positions)
+        logits = self.run_model(input_ids, positions, is_prefill)
         token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
-        seq_need_compute_logits = get_context().seq_need_compute_logits
         reset_context()
-        return token_ids, seq_need_compute_logits
+        return token_ids
 
     @torch.inference_mode()
     def capture_cudagraph(self):
@@ -242,7 +256,7 @@ class ModelRunner:
 
         for bs in reversed(self.graph_bs):
             graph = torch.cuda.CUDAGraph()
-            set_context(slot_mapping=slot_mapping[:bs], context_lens=context_lens[:bs], block_tables=block_tables[:bs])
+            set_context(False, slot_mapping=slot_mapping[:bs], context_lens=context_lens[:bs], block_tables=block_tables[:bs])
             outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # warmup
             with torch.cuda.graph(graph, self.graph_pool):
                 outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # capture

--- a/nanovllm/layers/attention.py
+++ b/nanovllm/layers/attention.py
@@ -62,10 +62,27 @@ class Attention(nn.Module):
         if k_cache.numel() and v_cache.numel():
             store_kvcache(k, v, k_cache, v_cache, context.slot_mapping)
 
-        if context.block_tables is not None:    # prefix cache
-            k, v = k_cache, v_cache
-        o = flash_attn_varlen_func(q, k, v,
-                                    max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,
-                                    max_seqlen_k=context.max_seqlen_k, cu_seqlens_k=context.cu_seqlens_k,
-                                    softmax_scale=self.scale, causal=True, block_table=context.block_tables)
+        if context.is_pure_decode:
+            # Decode-only: all inputs are static-shape tensors already in
+            # graph_vars, so this path is safe for CUDA graph replay.
+            # flash_attn_with_kvcache expects q: [bs, seqlen_q, nheads, d]
+            # but our q is [bs, nheads, d], so unsqueeze the seqlen dim.
+            o = flash_attn_with_kvcache(
+                q.unsqueeze(1), k_cache, v_cache,
+                cache_seqlens=context.context_lens,
+                block_table=context.block_tables,
+                softmax_scale=self.scale,
+                causal=True,
+            )
+            o = o.squeeze(1)  # [bs, 1, nheads, d] -> [bs, nheads, d]
+        else:
+            # Prefill or chunked-prefill: variable seqlen, eager only.
+            if context.block_tables is not None:    # prefix cache
+                k, v = k_cache, v_cache
+            o = flash_attn_varlen_func(
+                q, k, v,
+                max_seqlen_q=context.max_seqlen_q, cu_seqlens_q=context.cu_seqlens_q,
+                max_seqlen_k=context.max_seqlen_k, cu_seqlens_k=context.cu_seqlens_k,
+                softmax_scale=self.scale, causal=True, block_table=context.block_tables,
+            )
         return o

--- a/nanovllm/utils/context.py
+++ b/nanovllm/utils/context.py
@@ -13,6 +13,27 @@ class Context:
     block_tables: torch.Tensor | None = None
     seq_need_compute_logits: torch.Tensor | None = None
 
+
+    @property
+
+    def is_pure_decode(self) -> bool:
+
+        """True when this is a decode-only batch with no prefill tokens.
+
+        During CUDA graph capture and replay, set_context() is called without
+
+        cu_seqlens_q (it remains None). At runtime, _is_decode_only() in
+
+        ModelRunner guarantees graph replay only happens for pure-decode batches,
+
+        so cu_seqlens_q being None is a reliable signal for the attention layer
+
+        to select the graph-compatible flash_attn_with_kvcache path.
+
+        """
+
+        return self.cu_seqlens_q is None
+
 _CONTEXT = Context()
 
 def get_context():

--- a/tests/test_cuda_graph_chunked_prefill.py
+++ b/tests/test_cuda_graph_chunked_prefill.py
@@ -1,0 +1,429 @@
+"""
+tests/test_cuda_graph_chunked_prefill.py
+
+Unit tests for CUDA graph + chunked prefill compatibility (PR #1).
+
+Strategy: avoid the nanovllm/__init__.py -> llm -> llm_engine -> transformers
+-> accelerate -> torch.distributed chain entirely. Instead:
+
+  1. Inline the three tiny helper classes (SamplingParams, Context, Sequence)
+     directly in this file -- they have zero external dependencies beyond stdlib.
+  2. Inline _is_decode_only and the use_graph gate as pure Python so the
+     logic tests need no mocking at all.
+  3. For the ModelRunner integration tests, load model_runner.py directly via
+     importlib AFTER patching every heavy dependency, so the real
+     torch.distributed is never replaced.
+
+All 16 tests run with no GPU, no CUDA, no flash-attn, no transformers.
+"""
+
+import sys
+import types
+import unittest
+import importlib.util
+import pathlib
+from copy import copy
+from dataclasses import dataclass
+from enum import Enum, auto
+from itertools import count
+from unittest.mock import MagicMock
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# 1. Inline minimal helpers (zero imports from nanovllm)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SamplingParams:
+    temperature: float = 1.0
+    max_tokens: int = 64
+    ignore_eos: bool = False
+
+
+@dataclass
+class Context:
+    cu_seqlens_q: object = None
+    cu_seqlens_k: object = None
+    max_seqlen_q: int = 0
+    max_seqlen_k: int = 0
+    slot_mapping: object = None
+    context_lens: object = None
+    block_tables: object = None
+    seq_need_compute_logits: object = None
+
+
+_CONTEXT = Context()
+
+
+def get_context():
+    return _CONTEXT
+
+
+def set_context(cu_seqlens_q=None, cu_seqlens_k=None, max_seqlen_q=0,
+                max_seqlen_k=0, slot_mapping=None, context_lens=None,
+                block_tables=None, seq_need_compute_logits=None):
+    global _CONTEXT
+    _CONTEXT = Context(cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+                       slot_mapping, context_lens, block_tables,
+                       seq_need_compute_logits)
+
+
+def reset_context():
+    global _CONTEXT
+    _CONTEXT = Context()
+
+
+class SequenceStatus(Enum):
+    WAITING = auto()
+    RUNNING = auto()
+    FINISHED = auto()
+
+
+class Sequence:
+    block_size = 256
+    counter = count()
+
+    def __init__(self, token_ids, sampling_params=None):
+        if sampling_params is None:
+            sampling_params = SamplingParams()
+        self.seq_id = next(Sequence.counter)
+        self.status = SequenceStatus.WAITING
+        self.token_ids = copy(token_ids)
+        self.last_token = token_ids[-1]
+        self.num_tokens = len(self.token_ids)
+        self.num_prompt_tokens = len(token_ids)
+        self.num_cached_tokens = 0
+        self.num_new_tokens = 0
+        self.block_table = []
+        self.temperature = sampling_params.temperature
+        self.max_tokens = sampling_params.max_tokens
+        self.ignore_eos = sampling_params.ignore_eos
+
+    def __len__(self):
+        return self.num_tokens
+
+    def __getitem__(self, key):
+        return self.token_ids[key]
+
+    @property
+    def num_context_tokens(self):
+        return self.num_cached_tokens + self.num_new_tokens
+
+    @property
+    def num_cached_blocks(self):
+        return self.num_cached_tokens // self.block_size
+
+
+# ---------------------------------------------------------------------------
+# 2. The two methods under test, inlined verbatim from model_runner.py
+# ---------------------------------------------------------------------------
+
+def _is_decode_only(seqs) -> bool:
+    return all(seq.num_new_tokens == 1 for seq in seqs)
+
+
+def _use_graph(enforce_eager: bool, input_ids_size: int, seqs) -> bool:
+    return (
+        not enforce_eager
+        and input_ids_size <= 512
+        and seqs is not None
+        and _is_decode_only(seqs)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Load ModelRunner without triggering the heavy import chain
+# ---------------------------------------------------------------------------
+
+def _load_model_runner():
+    repo_root = pathlib.Path(__file__).parent.parent
+
+    # Build stub modules for everything model_runner imports at module level.
+    # Critically: we do NOT stub torch.distributed -- the real one stays.
+    ctx_stub = types.ModuleType("nanovllm.utils.context")
+    ctx_stub.Context = Context
+    ctx_stub.get_context = get_context
+    ctx_stub.set_context = set_context
+    ctx_stub.reset_context = reset_context
+
+    seq_stub = types.ModuleType("nanovllm.engine.sequence")
+    seq_stub.Sequence = Sequence
+    seq_stub.SequenceStatus = SequenceStatus
+
+    stubs = {
+        "flash_attn":                  MagicMock(),
+        "triton":                      MagicMock(),
+        "triton.language":             MagicMock(),
+        "nanovllm.utils.context":      ctx_stub,
+        "nanovllm.engine.sequence":    seq_stub,
+        "nanovllm.layers.sampler":     MagicMock(),
+        "nanovllm.models.qwen3":       MagicMock(),
+        "nanovllm.utils.loader":       MagicMock(),
+        "nanovllm.config":             MagicMock(),
+    }
+
+    saved = {name: sys.modules.get(name) for name in stubs}
+    for name, stub in stubs.items():
+        sys.modules[name] = stub
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "nanovllm.engine.model_runner",
+            repo_root / "nanovllm" / "engine" / "model_runner.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        # Inject a mock dist directly into the module's namespace so the
+        # import at the top of model_runner.py ("import torch.distributed as dist")
+        # is shadowed before any method calls it.
+        mod.dist = MagicMock()
+        sys.modules["nanovllm.engine.model_runner"] = mod
+        spec.loader.exec_module(mod)
+        return mod.ModelRunner
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+ModelRunner = _load_model_runner()
+
+
+# ---------------------------------------------------------------------------
+# 4. Shared test helpers
+# ---------------------------------------------------------------------------
+
+def make_seq(num_new_tokens: int, num_cached_tokens: int = 0) -> Sequence:
+    token_ids = [0] * max(num_cached_tokens + num_new_tokens, 1)
+    seq = Sequence(token_ids)
+    seq.num_cached_tokens = num_cached_tokens
+    seq.num_new_tokens = num_new_tokens
+    seq.block_table = [0]
+    return seq
+
+
+def make_runner(enforce_eager: bool = False) -> ModelRunner:
+    hidden = 64
+    max_bs = 32
+    max_num_blocks = 16
+
+    runner = object.__new__(ModelRunner)
+    runner.enforce_eager = enforce_eager
+    runner.world_size = 1
+    runner.rank = 0
+    runner.block_size = 256
+
+    mock_model = MagicMock()
+    mock_model.return_value = torch.zeros(max_bs, hidden)
+    mock_model.compute_logits = MagicMock(
+        side_effect=lambda x: torch.zeros(x.size(0), 32000)
+    )
+    runner.model = mock_model
+    runner.graph_bs = [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))
+    runner.graph_vars = dict(
+        input_ids=torch.zeros(max_bs, dtype=torch.int64),
+        positions=torch.zeros(max_bs, dtype=torch.int64),
+        slot_mapping=torch.full((max_bs,), -1, dtype=torch.int32),
+        context_lens=torch.zeros(max_bs, dtype=torch.int32),
+        block_tables=torch.zeros(max_bs, max_num_blocks, dtype=torch.int32),
+        outputs=torch.zeros(max_bs, hidden),
+    )
+    runner.graphs = {bs: MagicMock() for bs in runner.graph_bs}
+    return runner
+
+
+def set_decode_ctx(bs: int):
+    reset_context()
+    set_context(
+        slot_mapping=torch.zeros(bs, dtype=torch.int32),
+        context_lens=torch.ones(bs, dtype=torch.int32) * 5,
+        block_tables=torch.zeros(bs, 4, dtype=torch.int32),
+    )
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+class TestIsDecodeOnly(unittest.TestCase):
+
+    def test_single_decode_seq(self):
+        self.assertTrue(_is_decode_only([make_seq(1, 10)]))
+
+    def test_batch_all_decode(self):
+        self.assertTrue(_is_decode_only([make_seq(1, i + 5) for i in range(8)]))
+
+    def test_single_first_prefill(self):
+        self.assertFalse(_is_decode_only([make_seq(50, 0)]))
+
+    def test_chunked_prefill_mid_chunk(self):
+        self.assertFalse(_is_decode_only([make_seq(32, 64)]))
+
+    def test_mixed_prefill_and_decode(self):
+        self.assertFalse(_is_decode_only([make_seq(1, 20), make_seq(1, 15), make_seq(16, 0)]))
+
+    def test_last_prefill_chunk(self):
+        self.assertFalse(_is_decode_only([make_seq(2, 62)]))
+
+    def test_all_prefill_batch(self):
+        self.assertFalse(_is_decode_only([make_seq(64, 0) for _ in range(4)]))
+
+
+class TestUseGraphGate(unittest.TestCase):
+
+    def test_enforce_eager_blocks_graph(self):
+        self.assertFalse(_use_graph(True, 4, [make_seq(1, 10)] * 4))
+
+    def test_decode_only_gets_graph(self):
+        self.assertTrue(_use_graph(False, 4, [make_seq(1, 10)] * 4))
+
+    def test_prefill_blocks_graph(self):
+        self.assertFalse(_use_graph(False, 1, [make_seq(32, 0)]))
+
+    def test_mixed_blocks_graph(self):
+        self.assertFalse(_use_graph(False, 2, [make_seq(1, 10), make_seq(16, 0)]))
+
+    def test_large_bs_blocks_graph(self):
+        self.assertFalse(_use_graph(False, 513, [make_seq(1, 5)] * 4))
+
+    def test_seqs_none_blocks_graph(self):
+        self.assertFalse(_use_graph(False, 1, None))
+
+
+class TestRunModelRouting(unittest.TestCase):
+
+    def tearDown(self):
+        reset_context()
+
+    def test_enforce_eager_always_eager(self):
+        runner = make_runner(enforce_eager=True)
+        set_decode_ctx(4)
+        runner.run_model(torch.zeros(4, dtype=torch.int64),
+                         torch.zeros(4, dtype=torch.int64),
+                         [make_seq(1, 10)] * 4)
+        runner.model.assert_called_once()
+        for g in runner.graphs.values():
+            g.replay.assert_not_called()
+
+    def test_decode_only_uses_graph(self):
+        runner = make_runner(enforce_eager=False)
+        bs = 4
+        set_decode_ctx(bs)
+        runner.run_model(torch.zeros(bs, dtype=torch.int64),
+                         torch.zeros(bs, dtype=torch.int64),
+                         [make_seq(1, 10)] * bs)
+        runner.model.assert_not_called()
+        bucket = next(x for x in runner.graph_bs if x >= bs)
+        runner.graphs[bucket].replay.assert_called_once()
+
+    def test_graph_bucket_selection(self):
+        runner = make_runner(enforce_eager=False)
+        bs = 5
+        set_decode_ctx(bs)
+        runner.run_model(torch.zeros(bs, dtype=torch.int64),
+                         torch.zeros(bs, dtype=torch.int64),
+                         [make_seq(1, 10)] * bs)
+        runner.graphs[8].replay.assert_called_once()
+        runner.graphs[4].replay.assert_not_called()
+
+    def test_prefill_uses_eager(self):
+        runner = make_runner(enforce_eager=False)
+        set_decode_ctx(1)
+        runner.run_model(torch.zeros(1, dtype=torch.int64),
+                         torch.zeros(1, dtype=torch.int64),
+                         [make_seq(32, 0)])
+        runner.model.assert_called_once()
+        for g in runner.graphs.values():
+            g.replay.assert_not_called()
+
+    def test_mixed_batch_uses_eager(self):
+        runner = make_runner(enforce_eager=False)
+        set_decode_ctx(2)
+        runner.run_model(torch.zeros(2, dtype=torch.int64),
+                         torch.zeros(2, dtype=torch.int64),
+                         [make_seq(1, 20), make_seq(16, 0)])
+        runner.model.assert_called_once()
+        for g in runner.graphs.values():
+            g.replay.assert_not_called()
+
+    def test_large_batch_uses_eager(self):
+        runner = make_runner(enforce_eager=False)
+        set_decode_ctx(4)
+        runner.run_model(torch.zeros(513, dtype=torch.int64),
+                         torch.zeros(513, dtype=torch.int64),
+                         [make_seq(1, 5)] * 513)
+        runner.model.assert_called_once()
+        for g in runner.graphs.values():
+            g.replay.assert_not_called()
+
+    def test_seqs_none_uses_eager(self):
+        runner = make_runner(enforce_eager=False)
+        set_decode_ctx(1)
+        runner.run_model(torch.zeros(1, dtype=torch.int64),
+                         torch.zeros(1, dtype=torch.int64),
+                         seqs=None)
+        runner.model.assert_called_once()
+        for g in runner.graphs.values():
+            g.replay.assert_not_called()
+
+
+class TestBlockTablesZeroed(unittest.TestCase):
+
+    def tearDown(self):
+        reset_context()
+
+    def _ctx(self, bs, block_val):
+        reset_context()
+        set_context(
+            slot_mapping=torch.zeros(bs, dtype=torch.int32),
+            context_lens=torch.ones(bs, dtype=torch.int32),
+            block_tables=torch.full((bs, 2), block_val, dtype=torch.int32),
+        )
+
+    def test_stale_block_tables_are_cleared(self):
+        runner = make_runner(enforce_eager=False)
+
+        # Step 1: large batch (bs=8), block_id=99
+        self._ctx(8, 99)
+        runner.run_model(torch.zeros(8, dtype=torch.int64),
+                         torch.zeros(8, dtype=torch.int64),
+                         [make_seq(1, 5)] * 8)
+
+        # Step 2: small batch (bs=2), block_id=7
+        self._ctx(2, 7)
+        runner.run_model(torch.zeros(2, dtype=torch.int64),
+                         torch.zeros(2, dtype=torch.int64),
+                         [make_seq(1, 5)] * 2)
+
+        bt = runner.graph_vars["block_tables"]
+        self.assertTrue((bt[:2, :2] == 7).all(),
+                        "Active rows should hold current block ids")
+        self.assertTrue((bt[2:] == 0).all(),
+                        "Padded rows must be zeroed, not carry stale ids")
+
+
+class TestSchedulingSimulation(unittest.TestCase):
+
+    def test_eager_then_graph_transition(self):
+        chunk_size = 4
+        prompt_len = 8
+
+        steps = [
+            (chunk_size, [make_seq(chunk_size, 0)]),
+            (chunk_size, [make_seq(chunk_size, chunk_size)]),
+            (1,          [make_seq(1, prompt_len)]),
+            (1,          [make_seq(1, prompt_len + 1)]),
+        ]
+
+        eager = sum(1 for bs, seqs in steps if not _use_graph(False, bs, seqs))
+        graph = sum(1 for bs, seqs in steps if _use_graph(False, bs, seqs))
+
+        self.assertEqual(eager, 2, "Prefill steps should be eager")
+        self.assertEqual(graph, 2, "Decode steps should use CUDA graph")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
CUDA graphs require static input tensor shapes at replay time. The original code broke silently when chunked_prefill=True because prefill iterations produce variable-length query sequences (seqlen_q > 1) and can mix prefill + decode sequences in the same batch.

Introduce _is_decode_only(seqs) which returns True iff every sequence has num_new_tokens == 1 (pure decode step). run_model() now gates CUDA-graph replay on this predicate, falling back to eager for any batch containing prefill tokens.

Also zero graph_vars['block_tables'] before each replay to prevent stale block pointers from leaking into padded rows.

Closes #1